### PR TITLE
Transpose Updates to Avoid Sorting

### DIFF
--- a/snapjax/algos.py
+++ b/snapjax/algos.py
@@ -17,21 +17,16 @@ config.update("jax_numpy_rank_promotion", "raise")
 
 
 @jax.jit
-def dense_coo_product(D: Array, J: BCOO, sp: Array):
-    orig_shape = J.shape
-    J = J.transpose()
+def dense_coo_product(D: Array, J_T: BCOO, sp_T: Array):
+    orig_shape = J_T.shape
 
     # TO CSR
-    J = BCSR.from_bcoo(J)
-    D = D.T
-    # Transpose also the sparsity pattern.
-    sp_T = sp.at[:, 0].set(sp[:, 1])
-    sp_T = sp_T.at[:, 1].set(sp[:, 0])
+    J_T = BCSR.from_bcoo(J_T)
+    D_T = D.T
 
-    data = spp_csr_matmul(J.data, J.indices, J.indptr, D, sp_T)
+    data = spp_csr_matmul(J_T.data, J_T.indices, J_T.indptr, D_T, sp_T)
 
-    # No need to do the transpose since, sp is already in the shape we want.
-    return BCOO((data, sp), shape=orig_shape, indices_sorted=True, unique_indices=True)
+    return BCOO((data, sp_T), shape=J_T.shape, indices_sorted=True, unique_indices=True)
 
 
 @jax.jit
@@ -47,15 +42,17 @@ def sparse_matching_addition(A: BCOO, B: BCOO) -> BCOO:
 
 
 def _make_zeros_jacobians_bcco(sp_projection_tree: RTRLStacked):
+    # Jacobians are saved as the tranpose jacobians.
     def _sparse_jacobian(leaf: SparseProjection):
         zeros = jnp.zeros(leaf.sparse_def.nse)
-        indices = leaf.sparse_def.indices
+        indices = leaf.sparse_def.indices_csc[:, ::-1]  # For the transpose.
         structure = (zeros, indices)
         return BCOO(
             structure,
-            shape=leaf.sparse_def.shape,
-            indices_sorted=True,  # This is guaranteed in if sparse_def
-            unique_indices=True,  # is properly constructed.
+            shape=leaf.sparse_def.shape[::-1],  # For the transpose.
+            # This is guaranteed since csc arse sorted by colum and we transpose.
+            indices_sorted=True,
+            unique_indices=True,
         )
 
     zero_jacobians = jtu.tree_map(
@@ -133,18 +130,24 @@ def mask_by_it(i_t: BCOO, j_t: BCOO):
 
 
 @jax.jit
-def sparse_update(I_t: RTRLCell, dynamics: Array, J_t_prev: RTRLCell):
-    def _update_rtrl_bcco(i_t: BCOO, j_t_prev: BCOO) -> BCOO:
-        prod = dense_coo_product(dynamics, j_t_prev, j_t_prev.indices)
+def sparse_update(I_t_T: RTRLCell, dynamics: Array, J_t_prev_T: RTRLCell):
+    """
+    Returns the I + D*J(t_1) tranposed.
+    """
+
+    def _update_rtrl_bcco(i_t: BCOO, j_t_prev_T: BCOO) -> BCOO:
+        prod = dense_coo_product(dynamics, j_t_prev_T, j_t_prev_T.indices)
         return sparse_matching_addition(i_t, prod)
 
-    J_t = jax.tree_map(
-        lambda i_t, j_t_prev: mask_by_it(i_t, _update_rtrl_bcco(i_t, j_t_prev)),
-        I_t,
-        J_t_prev,
+    J_t_T = jax.tree_map(
+        lambda i_t_T, j_t_prev_T: mask_by_it(
+            i_t_T, _update_rtrl_bcco(i_t_T, j_t_prev_T)
+        ),
+        I_t_T,
+        J_t_prev_T,
         is_leaf=lambda node: isinstance(node, BCOO),
     )
-    return J_t
+    return J_t_T
 
 
 @partial(jax.jit, static_argnums=(3, 4))
@@ -158,8 +161,8 @@ def update_cell_jacobians(
     # RTRL
     if use_snap_1:
         if sparse:
-            J_t = sparse_update(I_t, dynamics, J_t_prev)
-            return J_t
+            J_t_T = sparse_update(I_t, dynamics, J_t_prev)
+            return J_t_T
         else:
             # The theoretical one from the paper.
             J_t = jax.tree_map(
@@ -221,9 +224,14 @@ def update_rtrl_cells_grads(
 
     for i in range(grads.num_layers):
         ht_grad = hidden_states_grads[i]
+        if sparse:
+            matmul_by_h = jtu.Partial(lambda a, b: (b @ a.T).T, ht_grad)
+        else:
+            matmul_by_h = jtu.Partial(lambda a, b: a @ b, ht_grad)
+
         rtrl_cell_jac = jacobians.layers[i].cell
         rtrl_cell_grads = jax.tree_map(
-            lambda jacobian: ht_grad @ jacobian,
+            lambda jacobian: matmul_by_h(jacobian),
             rtrl_cell_jac,
             is_leaf=_leaf_function(sparse),
         )

--- a/snapjax/cells/base.py
+++ b/snapjax/cells/base.py
@@ -2,7 +2,11 @@ from abc import abstractmethod
 from typing import Any, List, Sequence, Tuple
 
 import equinox as eqx
+import jax
+import jax.tree_util as jtu
 from jaxtyping import Array
+
+from snapjax.sp_jacrev import sp_projection_tree
 
 State = Sequence[Array]
 Jacobians = Tuple["RTRLCell", Array]  # I_t, D_t
@@ -43,6 +47,8 @@ class RTRLLayer(eqx.Module):
     """
 
     cell: eqx.AbstractVar[RTRLCell]
+    d_inp: eqx.AbstractVar[int]
+    d_out: eqx.AbstractVar[int]
 
     @abstractmethod
     def f(
@@ -66,8 +72,6 @@ class RTRLStacked(eqx.Module):
 
     layers: eqx.AbstractVar[List[RTRLLayer]]
     num_layers: eqx.AbstractVar[int]
-    d_inp: eqx.AbstractVar[int]
-    d_out: eqx.AbstractVar[int]
 
     @abstractmethod
     def f(
@@ -79,9 +83,32 @@ class RTRLStacked(eqx.Module):
     ) -> Tuple[Sequence[State], Sequence[Jacobians], Array]:
         ...
 
-    @abstractmethod
     def get_sp_projection_tree(self) -> "RTRLStacked":
-        ...
+        """
+        Gets the sparse projection tree, from only
+        the layers annotated as RTRLCell.
+        """
+        default = jax.default_backend()
+        cpu_device = jax.devices("cpu")[0]
+
+        # Move the RNN to CPU, to avoid creating the
+        # explicit jacobians in the GPU.
+        cells = eqx.filter(self, lambda leaf: is_rtrl_cell(leaf), is_leaf=is_rtrl_cell)
+        cells = jtu.tree_map(lambda leaf: jax.device_put(leaf, cpu_device), cells)
+
+        with jax.default_device(jax.devices("cpu")[0]):
+            sp_tree = jtu.tree_map(
+                lambda cell: sp_projection_tree(cell.make_sp_pattern(cell)),
+                cells,
+                is_leaf=is_rtrl_cell,
+            )
+
+        # Move back to GPU once computed.
+        sp_tree = jtu.tree_map(
+            lambda leaf: jax.device_put(leaf, jax.devices(default)[0]), sp_tree
+        )
+
+        return sp_tree
 
 
 def is_rtrl_cell(node: Any):

--- a/snapjax/cells/base.py
+++ b/snapjax/cells/base.py
@@ -39,6 +39,7 @@ class RTRLCell(eqx.Module):
 class RTRLLayer(eqx.Module):
     """
     s_(t), theta_t, y_(t) = f(s_(t-1), x(t))
+    where theta_t = (jacobians, dynamics).
     """
 
     cell: eqx.AbstractVar[RTRLCell]
@@ -51,6 +52,10 @@ class RTRLLayer(eqx.Module):
         perturbation: Array,
         sp_projection_cell: RTRLCell = None,
     ) -> Tuple[State, Jacobians, Array]:
+        """
+        If sp_projection_cell is not None, then the sparse jacobians must be
+        returned as transposed jacobians for efficieny in the algorithm.
+        """
         ...
 
 

--- a/snapjax/cells/base.py
+++ b/snapjax/cells/base.py
@@ -5,7 +5,7 @@ import equinox as eqx
 from jaxtyping import Array
 
 State = Sequence[Array]
-Jacobians = Tuple["RTRLCell", Sequence[Array]]
+Jacobians = Tuple["RTRLCell", Array]  # I_t, D_t
 
 
 class RTRLCell(eqx.Module):
@@ -27,7 +27,7 @@ class RTRLCell(eqx.Module):
 
     @staticmethod
     @abstractmethod
-    def make_zero_jacobians(cell: "RTRLCell") -> Jacobians:
+    def make_zero_jacobians(cell: "RTRLCell") -> "RTRLCell":
         ...
 
     @staticmethod

--- a/snapjax/cells/rnn.py
+++ b/snapjax/cells/rnn.py
@@ -147,7 +147,7 @@ class RNNLayer(RTRLLayer):
             dynamics_fun = jax.jacrev(RNN.f, argnums=1)
             dynamics = dynamics_fun(self.cell, state, input)
         else:
-            jacobian_func = jax.jit(jax.jacrev(RNN.f, argnums=(0, 1)))
+            jacobian_func = jax.jacrev(RNN.f, argnums=(0, 1))
             inmediate_jacobian, dynamics = jacobian_func(self.cell, state, input)
 
         # Project out

--- a/snapjax/cells/rnn.py
+++ b/snapjax/cells/rnn.py
@@ -9,7 +9,7 @@ from jax.experimental.sparse import BCOO
 from jaxtyping import Array, PRNGKeyArray
 
 from snapjax.cells.base import Jacobians, RTRLCell, RTRLLayer, State
-from snapjax.sp_jacrev import sp_jacrev, sp_projection_matrices
+from snapjax.sp_jacrev import sp_jacrev, sp_projection_tree
 
 
 class RNN(RTRLCell):

--- a/snapjax/cells/rnn.py
+++ b/snapjax/cells/rnn.py
@@ -61,7 +61,7 @@ class RNN(RTRLCell):
         h = state
         x = input
 
-        h_new = jnp.tanh(self.weights_hh @ h) + (self.weights_ih @ x) + bias
+        h_new = jnp.tanh(self.weights_hh @ h + self.weights_ih @ x + bias)
 
         return h_new
 
@@ -109,6 +109,8 @@ class RNNLayer(RTRLLayer):
     cell: RNN
     C: eqx.nn.Linear
     D: eqx.nn.Linear
+    d_inp: int = eqx.field(static=True)
+    d_out: int = eqx.field(static=True)
 
     def __init__(
         self,
@@ -121,7 +123,10 @@ class RNNLayer(RTRLLayer):
         cell_key, c_key, d_key = jax.random.split(key, 3)
         self.cell = RNN(hidden_size, input_size, use_bias=use_bias, key=cell_key)
         self.C = eqx.nn.Linear(hidden_size, hidden_size, use_bias=False, key=c_key)
-        self.D = eqx.nn.Linear(hidden_size, input_size, use_bias=False, key=d_key)
+        self.D = eqx.nn.Linear(input_size, hidden_size, use_bias=False, key=d_key)
+
+        self.d_inp = input_size
+        self.d_out = hidden_size
 
     def f(
         self,

--- a/snapjax/cells/rnn.py
+++ b/snapjax/cells/rnn.py
@@ -139,7 +139,9 @@ class RNNLayer(RTRLLayer):
         # Compute Jacobian and dynamics
         if sp_projection_cell:
             sp_jacobian_fun = sp_jacrev(
-                jtu.Partial(RNN.f, state=state, input=input), sp_projection_cell
+                jtu.Partial(RNN.f, state=state, input=input),
+                sp_projection_cell,
+                transpose=True,
             )
             inmediate_jacobian = sp_jacobian_fun(self.cell)
             dynamics_fun = jax.jacrev(RNN.f, argnums=1)

--- a/snapjax/cells/stacked.py
+++ b/snapjax/cells/stacked.py
@@ -13,7 +13,7 @@ from snapjax.cells.base import (
     State,
     is_rtrl_cell,
 )
-from snapjax.sp_jacrev import sp_projection_matrices
+from snapjax.sp_jacrev import sp_projection_tree
 
 
 class Stacked(RTRLStacked):
@@ -86,7 +86,7 @@ class Stacked(RTRLStacked):
 
         with jax.default_device(jax.devices("cpu")[0]):
             sp_tree = jtu.tree_map(
-                lambda cell: sp_projection_matrices(cell.make_sp_pattern(cell)),
+                lambda cell: sp_projection_tree(cell.make_sp_pattern(cell)),
                 cells,
                 is_leaf=is_rtrl_cell,
             )

--- a/snapjax/display-gpu-info.sh
+++ b/snapjax/display-gpu-info.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# This script displays GPU information in a more fine grained way.
+nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits | while IFS=, read -r gpu_uuid pid process_name used_memory; do
+  gpu_info=$(nvidia-smi --query-gpu=index,name,memory.total,gpu_uuid --format=csv,noheader | grep "$gpu_uuid")
+  username=$(ps -p $pid -o user --no-headers)
+  echo "User: $username, PID: $pid, Process: $process_name, Used Memory: $used_memory MB, GPU-Info: $gpu_info"
+done

--- a/snapjax/display-gpu-info.sh
+++ b/snapjax/display-gpu-info.sh
@@ -3,5 +3,5 @@
 nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits | while IFS=, read -r gpu_uuid pid process_name used_memory; do
   gpu_info=$(nvidia-smi --query-gpu=index,name,memory.total,gpu_uuid --format=csv,noheader | grep "$gpu_uuid")
   username=$(ps -p $pid -o user --no-headers)
-  echo "User: $username, PID: $pid, Process: $process_name, Used Memory: $used_memory MB, GPU-Info: $gpu_info"
+  echo "User: $username, PID: $pid, Process: $process_name, Used Memory: $used_memory MiB, GPU-Info: ${gpu_info%,*}"
 done

--- a/snapjax/sp_jacrev.py
+++ b/snapjax/sp_jacrev.py
@@ -164,7 +164,7 @@ def tree_vjp(fun, primal_tree: PyTree) -> PyTree:
     return jtu.tree_unflatten(in_tree, primals_vjp)
 
 
-def sp_projection_matrices(sparse_patterns: PyTree) -> PyTree:
+def sp_projection_tree(sparse_patterns: PyTree) -> PyTree:
     """
     Given a PyTree with sparse_patterns in BCOO format, it computes per leaf
     the structural orthogonal rows using a graph coloring algorithm, and the

--- a/snapjax/tests/jacrev_test.py
+++ b/snapjax/tests/jacrev_test.py
@@ -1,0 +1,122 @@
+import jax
+import jax.experimental.sparse as jsparse
+import jax.numpy as jnp
+import jax.tree_util as jtu
+import numpy as onp
+from jax.experimental.sparse.bcoo import BCOO
+
+from snapjax.sp_jacrev import sp_jacrev, sp_projection_tree
+
+_SIZE = 50
+
+# This units tests are test taken from
+# the sparsejac repo: github.com/mfschubert/sparsejac/
+# I just adapted them to make it work with pytest, by
+# just deleting the self argument for the test.
+
+
+class sparsejac:
+    @staticmethod
+    def jacrev(fn, sparsity):
+        jac_fun = sp_jacrev(fn, sp_projection_tree(sparsity))
+
+        def f(x):
+            tree = jac_fun(x)
+            # Transpose since I return the tranposed jacobian
+            # matrix.
+            return jtu.tree_map(
+                lambda jacobian: jacobian.transpose(),
+                tree,
+                is_leaf=lambda leaf: isinstance(leaf, BCOO),
+            )
+
+        return f
+
+
+def test_diagonal():
+    fn = lambda x: x**2
+    sparsity = jsparse.BCOO.fromdense(jnp.eye(_SIZE))
+    x = jax.random.uniform(jax.random.PRNGKey(0), shape=(_SIZE,))
+    actual = sparsejac.jacrev(fn, sparsity)(x)
+    onp.testing.assert_array_equal(jax.jacrev(fn)(x), actual.todense())
+
+
+def test_diagonal_jit():
+    fn = lambda x: x**2
+    sparsity = jsparse.BCOO.fromdense(jnp.eye(_SIZE))
+    x = jax.random.uniform(jax.random.PRNGKey(0), shape=(_SIZE,))
+    jacfn = sparsejac.jacrev(fn, sparsity)
+    jacfn = jax.jit(jacfn)
+    actual = jacfn(x)
+    onp.testing.assert_array_equal(jax.jacrev(fn)(x), actual.todense())
+
+
+def test_diagonal_shuffled():
+    fn = lambda x: jax.random.permutation(jax.random.PRNGKey(0), x**2)
+    x = jax.random.uniform(jax.random.PRNGKey(0), shape=(_SIZE,))
+    expected = jax.jacrev(fn)(x)
+    sparsity = jsparse.BCOO.fromdense(expected != 0)
+    actual = sparsejac.jacrev(fn, sparsity)(x)
+    onp.testing.assert_array_equal(jax.jacrev(fn)(x), actual.todense())
+
+
+def test_dense():
+    fn = lambda x: jnp.stack((jnp.sum(x), jnp.sum(x) ** 2, jnp.sum(x) ** 3))
+    sparsity = jsparse.BCOO.fromdense(jnp.ones((3, _SIZE)))
+    x = jax.random.uniform(jax.random.PRNGKey(0), shape=(_SIZE,))
+    actual = sparsejac.jacrev(fn, sparsity)(x)
+    onp.testing.assert_array_equal(jax.jacrev(fn)(x), actual.todense())
+
+
+def test_convolutional_1d():
+    fn = lambda x: jnp.convolve(x, jnp.asarray([1.0, -2.0, 1.0]), mode="valid")
+    x = jax.random.uniform(jax.random.PRNGKey(0), shape=(_SIZE,))
+    i, j = jnp.meshgrid(jnp.arange(_SIZE - 2), jnp.arange(_SIZE), indexing="ij")
+    sparsity = (i == j) | ((i + 1) == j) | ((i + 2) == j)
+    sparsity = jsparse.BCOO.fromdense(sparsity)
+    actual = sparsejac.jacrev(fn, sparsity)(x)
+    onp.testing.assert_array_equal(jax.jacrev(fn)(x), actual.todense())
+
+
+def test_convolutional_1d_nonlinear():
+    fn = lambda x: jnp.convolve(x, jnp.asarray([1.0, -2.0, 1.0]), mode="valid") ** 2
+    x = jax.random.uniform(jax.random.PRNGKey(0), shape=(_SIZE,))
+    i, j = jnp.meshgrid(jnp.arange(_SIZE - 2), jnp.arange(_SIZE), indexing="ij")
+    sparsity = (i == j) | ((i + 1) == j) | ((i + 2) == j)
+    sparsity = jsparse.BCOO.fromdense(sparsity)
+    actual = sparsejac.jacrev(fn, sparsity)(x)
+    onp.testing.assert_array_equal(jax.jacrev(fn)(x), actual.todense())
+
+
+def test_convolutional_2d():
+    shape_2d = (20, 20)
+
+    def fn(x_flat):
+        x = jnp.reshape(x_flat, shape_2d)
+        result = jax.scipy.signal.convolve2d(x, jnp.ones((3, 3)), mode="valid")
+        return result.flatten()
+
+    x_flat = jax.random.uniform(
+        jax.random.PRNGKey(0), shape=(shape_2d[0] * shape_2d[1],)
+    )
+    expected = jax.jacrev(fn)(x_flat)
+    sparsity = jsparse.BCOO.fromdense(expected != 0)
+    actual = sparsejac.jacrev(fn, sparsity)(x_flat)
+    onp.testing.assert_array_equal(expected, actual.todense())
+
+
+def test_convolutional_2d_nonlinear():
+    shape_2d = (20, 20)
+
+    def fn(x_flat):
+        x = jnp.reshape(x_flat, shape_2d)
+        result = jax.scipy.signal.convolve2d(x, jnp.ones((3, 3)), mode="valid")
+        return result.flatten() ** 2
+
+    x_flat = jax.random.uniform(
+        jax.random.PRNGKey(0), shape=(shape_2d[0] * shape_2d[1],)
+    )
+    expected = jax.jacrev(fn)(x_flat)
+    sparsity = jsparse.BCOO.fromdense(expected != 0)
+    actual = sparsejac.jacrev(fn, sparsity)(x_flat)
+    onp.testing.assert_array_equal(expected, actual.todense())

--- a/snapjax/tests/jacrev_test.py
+++ b/snapjax/tests/jacrev_test.py
@@ -18,7 +18,7 @@ _SIZE = 50
 class sparsejac:
     @staticmethod
     def jacrev(fn, sparsity):
-        jac_fun = sp_jacrev(fn, sp_projection_tree(sparsity))
+        jac_fun = sp_jacrev(fn, sp_projection_tree(sparsity), transpose=True)
 
         def f(x):
             tree = jac_fun(x)

--- a/snapjax/tests/utils.py
+++ b/snapjax/tests/utils.py
@@ -23,13 +23,11 @@ def get_stacked_rnn(
 
     layer_args = {
         "hidden_size": hidden_size,
-        "input_size": hidden_size,
+        "input_size": input_size,
     }
 
     theta = Stacked(
         RNNLayer,
-        d_inp=input_size,
-        d_out=input_size,
         num_layers=num_layers,
         cls_kwargs=layer_args,
         key=jrandom.PRNGKey(key),
@@ -44,7 +42,7 @@ def get_random_sequence(T: int, model: Stacked, seed: int | None = None):
     else:
         key = seed
 
-    inputs = jrandom.normal(jrandom.PRNGKey(key), shape=(T, model.d_inp))
+    inputs = jrandom.normal(jrandom.PRNGKey(key), shape=(T, model.layers[0].d_inp))
 
     return inputs
 
@@ -55,7 +53,9 @@ def get_random_batch(N: int, T: int, model: Stacked, seed: int | None = None):
     else:
         key = seed
 
-    batch_inputs = jrandom.normal(jrandom.PRNGKey(key), shape=(N, T, model.d_inp))
+    batch_inputs = jrandom.normal(
+        jrandom.PRNGKey(key), shape=(N, T, model.layers[0].d_inp)
+    )
 
     return batch_inputs
 


### PR DESCRIPTION
Change the updates to work in the transpose world an avoid sorting the indices when passing to CSR format.